### PR TITLE
Current user new implementation 

### DIFF
--- a/AskFm/AskFm.API/AskFm.API.csproj
+++ b/AskFm/AskFm.API/AskFm.API.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AutoMapper" Version="15.0.1" />
         <PackageReference Include="DotNetEnv" Version="3.1.1" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />

--- a/AskFm/AskFm.API/Controllers/CommentController.cs
+++ b/AskFm/AskFm.API/Controllers/CommentController.cs
@@ -90,7 +90,7 @@ public class CommentController : ControllerBase
     
     
     [HttpDelete("{id}/likes")]
-    public async Task<IActionResult> DeleteLike(int id)
+    public async Task<IActionResult> DeleteLike(int id, int userId)
     {
         try
         {
@@ -98,25 +98,26 @@ public class CommentController : ControllerBase
             if (comment == null)
                 throw new ArgumentException($"Comment with id {id} not found");
             
-            var userId = comment.UserId;
+            if (userId <= 0)
+                return BadRequest(new { message = "Invalid user id." });
             
-            await _commentLikeService.DeleteLikeAsync(id, userId.Value);
+            await _commentLikeService.DeleteLikeAsync(id, userId);
             
             return NoContent();
         }
         catch (ArgumentException ex)
         {
-            _logger.LogWarning(ex, "Like not found for comment id: {CommentId} and user", id);
+            _logger.LogWarning(ex, "Like not found for comment id: {CommentId} and user {UserId}", id, userId);
             return NotFound(new { message = ex.Message });
         }
         catch (UnauthorizedAccessException ex)
         {
-            _logger.LogWarning(ex, "Unauthorized delete attempt for comment id: {CommentId}", id);
+            _logger.LogWarning(ex, "Unauthorized delete attempt for comment id: {CommentId} by user {UserId}", id, userId);
             return Forbid();
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting like from comment id: {CommentId}", id);
+            _logger.LogError(ex, "Error deleting like from comment id: {CommentId} by user {UserId}", id, userId);
             return StatusCode(500, new { message = "An error occurred while deleting like" });
         }
     }

--- a/AskFm/AskFm.API/Controllers/CommentController.cs
+++ b/AskFm/AskFm.API/Controllers/CommentController.cs
@@ -1,0 +1,124 @@
+using AskFm.BLL.DTO;
+using AskFm.BLL.Services;
+using AskFm.DAL.Interfaces;
+using AutoMapper;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AskFm.API.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class CommentController : ControllerBase
+{
+    
+    private readonly ICommentLikeService _commentLikeService;
+    private readonly ICommentService _commentService;
+    private readonly ILogger<CommentController> _logger;
+    
+    
+    public CommentController(
+        ICommentLikeService commentLikeService,
+        ICommentService commentService,
+        ILogger<CommentController> logger)
+    {
+        _commentLikeService = commentLikeService;
+        _logger = logger;
+        _commentService = commentService;
+    }
+    
+    
+    
+    
+    
+    // GET api/comment/{id}/likes -> get all the likes for a Comment with id = id
+    [HttpGet("{id}/likes")]
+    public async Task<IActionResult> GetAllLikes(int id)
+    {
+        try
+        {
+            var likes = await _commentLikeService.GetLikesForCommentAsync(id);
+            return Ok(likes);
+        }
+        catch (ArgumentException ex)
+        {
+            _logger.LogWarning(ex, "Comment not found with id: {CommentId}", id);
+            return NotFound(new { message = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving likes for comment id: {CommentId}", id);
+            return StatusCode(500, new { message = "An error occurred while retrieving likes" });
+        }
+    }
+    
+    
+    
+    
+    // POST api/comment/{id}/likes -> add a like for a Comment with id = id
+    [HttpPost("{id}/likes")]
+    public async Task<IActionResult> AddLike(int id, [FromBody] CreateCommentLikeDto likeDto)
+    {
+        try
+        {
+            var userId = likeDto.UserId;
+            
+            var createdLike = await _commentLikeService.AddLikeAsync(id, userId);
+            
+            return CreatedAtAction(
+                nameof(GetAllLikes), 
+                new { id = id }, 
+                createdLike);
+        }
+        catch (ArgumentException ex)
+        {
+            _logger.LogWarning(ex, "Invalid request to add like to comment id: {CommentId}", id);
+            return BadRequest(new { message = ex.Message });
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex, "Cannot add like to comment id: {CommentId}", id);
+            return Conflict(new { message = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error adding like to comment id: {CommentId}", id);
+            return StatusCode(500, new { message = "An error occurred while adding like" });
+        }
+    }
+    
+    
+    
+    
+    [HttpDelete("{id}/likes")]
+    public async Task<IActionResult> DeleteLike(int id)
+    {
+        try
+        {
+            var comment = _commentService.GetComment(id);
+            if (comment == null)
+                throw new ArgumentException($"Comment with id {id} not found");
+            
+            var userId = comment.UserId;
+            
+            await _commentLikeService.DeleteLikeAsync(id, userId.Value);
+            
+            return NoContent();
+        }
+        catch (ArgumentException ex)
+        {
+            _logger.LogWarning(ex, "Like not found for comment id: {CommentId} and user", id);
+            return NotFound(new { message = ex.Message });
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogWarning(ex, "Unauthorized delete attempt for comment id: {CommentId}", id);
+            return Forbid();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting like from comment id: {CommentId}", id);
+            return StatusCode(500, new { message = "An error occurred while deleting like" });
+        }
+    }
+    
+}

--- a/AskFm/AskFm.API/Controllers/UserController.cs
+++ b/AskFm/AskFm.API/Controllers/UserController.cs
@@ -37,16 +37,25 @@ public class UserController : ControllerBase
     }
 
     [HttpGet]
-    [Route("current-user")]
+    [Route("profile")]
     public async Task<IActionResult> GetCurrentUserAsync()
     {
         var result = await _userService.GetCurrentUserAsync();
-
+        
         if (!result.success)
         {
             return BadRequest(result.Errors);
         }
-        return Ok(result.Data);
+        ReadUserDTO readUserDTO = new ReadUserDTO()
+        {
+            Name = result.Data.Name,
+            Email = result.Data.Email,
+            AvatarPath = result.Data.AvatarPath,
+            Bio = result.Data.Bio,
+            followerCount = result.Data.FollowersCount,
+            LastSeen = result.Data.LastSeen,
+        };
+        return Ok(readUserDTO);
     }
     /*
   GET Users only for now

--- a/AskFm/AskFm.API/Program.cs
+++ b/AskFm/AskFm.API/Program.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using AskFm.BLL.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity;
 using AskFm.DAL;
@@ -44,6 +45,8 @@ public class Program
         builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
         builder.Services.AddScoped<IAuthService, AuthService>();
         builder.Services.AddScoped<IUserService, UserService>();
+        builder.Services.AddScoped<ICommentLikeService, CommentLikeService>();
+        builder.Services.AddScoped<ICommentService, CommentService>();
         builder.Services.AddControllers();
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddSwaggerGen();

--- a/AskFm/AskFm.API/Properties/launchSettings.json
+++ b/AskFm/AskFm.API/Properties/launchSettings.json
@@ -4,7 +4,8 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": false,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
       "applicationUrl": "http://localhost:5180",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -13,7 +14,8 @@
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": false,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7115;http://localhost:5180",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/AskFm/AskFm.BLL/AskFm.BLL.csproj
+++ b/AskFm/AskFm.BLL/AskFm.BLL.csproj
@@ -12,6 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="AutoMapper" Version="15.0.1" />
       <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
     </ItemGroup>
 

--- a/AskFm/AskFm.BLL/DTO/CommentLikeDto.cs
+++ b/AskFm/AskFm.BLL/DTO/CommentLikeDto.cs
@@ -1,0 +1,9 @@
+namespace AskFm.BLL.DTO;
+
+public class CommentLikeDto
+{
+    public int CommentId { get; set; }
+    public int UserId { get; set; }
+    public string UserName { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/AskFm/AskFm.BLL/DTO/CreateCommentLikeDto.cs
+++ b/AskFm/AskFm.BLL/DTO/CreateCommentLikeDto.cs
@@ -1,0 +1,8 @@
+namespace AskFm.BLL.DTO;
+
+public class CreateCommentLikeDto
+{
+    public int CommentId;
+    public int UserId;
+    public DateTime CreatedAt;
+}

--- a/AskFm/AskFm.BLL/Services/CommentLikeService.cs
+++ b/AskFm/AskFm.BLL/Services/CommentLikeService.cs
@@ -1,0 +1,147 @@
+using AskFm.BLL.DTO;
+using AskFm.DAL.Interfaces;
+using AskFm.DAL.Models;
+using AutoMapper;
+using Microsoft.Extensions.Logging;
+
+namespace AskFm.BLL.Services;
+
+public class CommentLikeService :  ICommentLikeService
+{
+    
+    private IUnitOfWork _unitOfWork;
+    private readonly ILogger<CommentLikeService> _logger;
+    private readonly IMapper _mapper;
+    public CommentLikeService(IUnitOfWork unitOfWork,  ILogger<CommentLikeService> logger)
+    {
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+    
+    
+    
+    public async Task<IEnumerable<CommentLikeDto>> GetLikesForCommentAsync(int commentId)
+    {
+        try
+        {
+            _logger.LogInformation("Retrieving likes for comment id: {CommentId}", commentId);
+
+            var comment = await _unitOfWork.Comments.GetByIdAsync(commentId);
+            if (comment == null)
+            {
+                throw new ArgumentException($"Comment with id {commentId} not found");
+            }
+
+            var likes = await _unitOfWork.CommentLikes.FindAllAsync(
+                predicate: cl => cl.CommentId == commentId && !cl.IsDeleted
+            );
+
+            var likeDtos = likes.Select(like => new CommentLikeDto
+            {
+                CommentId = like.CommentId,
+                UserId = like.UserId,
+                CreatedAt = like.CreatedAt,
+                UserName = like.User?.UserName
+            });
+
+            return likeDtos;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving likes for comment id: {CommentId}", commentId);
+            throw;
+        }    
+    }
+
+    public async Task<CommentLikeDto> AddLikeAsync(int commentId, int userId)
+    {
+        try
+            {
+                _logger.LogInformation("Adding like for comment id: {CommentId} by user id: {UserId}", 
+                    commentId, userId);
+
+                var comment = await _unitOfWork.Comments.GetByIdAsync(commentId);
+                
+                if (comment == null)
+                {
+                    throw new ArgumentException($"Comment with id {commentId} not found");
+                }
+
+                var existingLike = await _unitOfWork.CommentLikes.FindAsync(
+                    cl => cl.CommentId == commentId && cl.UserId == userId && !cl.IsDeleted
+                );
+
+                if (existingLike != null)
+                {
+                    throw new InvalidOperationException("User has already liked this comment");
+                }
+
+                var newLike = new CommentLike
+                {
+                    CommentId = commentId,
+                    UserId = userId,
+                };
+
+                await _unitOfWork.CommentLikes.AddAsync(newLike);
+                
+                comment.LikeCount++;
+                _unitOfWork.Comments.Update(comment);
+
+                await _unitOfWork.SaveAsync();
+
+                _logger.LogInformation("Like added successfully for comment id: {CommentId}", commentId);
+
+                
+                var user = await _unitOfWork.Users.GetByIdAsync(userId);
+                string userName = user.UserName;
+                
+                
+                return new CommentLikeDto
+                {
+                    CommentId = newLike.CommentId,
+                    UserId = newLike.UserId,
+                    UserName = userName,
+                    CreatedAt = newLike.CreatedAt
+                };
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error adding like for comment id: {CommentId} by user id: {UserId}", 
+                    commentId, userId);
+                throw;
+            }
+        
+    }
+    
+
+    public async Task DeleteLikeAsync(int commentId, int userId)
+    {
+        try
+        {
+            _logger.LogInformation("Deleting the comment like from user {userid} on comment id {commentId}", userId, commentId);
+            var commentLike = await _unitOfWork.CommentLikes.FindAsync(cl => cl.CommentId == commentId && cl.UserId == userId && !cl.IsDeleted);
+
+            var comment = _unitOfWork.Comments.GetByIdAsync(commentId);
+            
+            Console.WriteLine(comment.Result.Content);
+            
+            // if the user didn't like  this comment before 
+            if(commentLike == null)
+                throw new ArgumentException($"User didn't like this comment");
+            
+            await _unitOfWork.CommentLikes.RemoveAsync(commentLike);
+            
+            comment.Result.IsDeleted = true;
+            comment.Result.CommentLikes.Remove(commentLike);
+            comment.Result.LikeCount--;
+            
+            await _unitOfWork.SaveAsync();
+            
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            throw;
+        }
+    }
+}

--- a/AskFm/AskFm.BLL/Services/CommentLikeService.cs
+++ b/AskFm/AskFm.BLL/Services/CommentLikeService.cs
@@ -93,6 +93,10 @@ public class CommentLikeService :  ICommentLikeService
 
                 
                 var user = await _unitOfWork.Users.GetByIdAsync(userId);
+                
+                if (user == null)
+                    throw new ArgumentException($"User with id {userId} not found");
+                
                 string userName = user.UserName;
                 
                 

--- a/AskFm/AskFm.BLL/Services/CommentLikeService.cs
+++ b/AskFm/AskFm.BLL/Services/CommentLikeService.cs
@@ -118,7 +118,7 @@ public class CommentLikeService :  ICommentLikeService
     }
     
 
-    public async Task DeleteLikeAsync(int commentId, int userId)
+    public async Task<bool> DeleteLikeAsync(int commentId, int userId)
     {
         try
         {
@@ -130,7 +130,9 @@ public class CommentLikeService :  ICommentLikeService
                 throw new ArgumentException($"User didn't like this comment");
             
             
-            var commentLike = await _unitOfWork.CommentLikes.FindAsync(cl => cl.CommentId == commentId && cl.UserId == userId && !cl.IsDeleted);
+            var commentLike = await 
+                _unitOfWork.CommentLikes.FindAsync(
+                    predicate: cl => cl.CommentId == commentId && cl.UserId == userId && !cl.IsDeleted);
             
             // if the user didn't like  this comment before 
             if(commentLike == null)
@@ -145,10 +147,10 @@ public class CommentLikeService :  ICommentLikeService
             if (comment.LikeCount > 0)
                     comment.LikeCount--;
             
-           _unitOfWork.Comments.Update(comment);
+            _unitOfWork.Comments.Update(comment);
             
             await _unitOfWork.SaveAsync();
-            
+            return true;
         }
         catch (Exception e)
         {

--- a/AskFm/AskFm.BLL/Services/CommentLikeService.cs
+++ b/AskFm/AskFm.BLL/Services/CommentLikeService.cs
@@ -123,11 +123,14 @@ public class CommentLikeService :  ICommentLikeService
         try
         {
             _logger.LogInformation("Deleting the comment like from user {userid} on comment id {commentId}", userId, commentId);
-            var commentLike = await _unitOfWork.CommentLikes.FindAsync(cl => cl.CommentId == commentId && cl.UserId == userId && !cl.IsDeleted);
-
-            var comment = _unitOfWork.Comments.GetByIdAsync(commentId);
             
-            Console.WriteLine(comment.Result.Content);
+            var comment = await _unitOfWork.Comments.GetByIdAsync(commentId);
+            
+            if(comment == null)
+                throw new ArgumentException($"User didn't like this comment");
+            
+            
+            var commentLike = await _unitOfWork.CommentLikes.FindAsync(cl => cl.CommentId == commentId && cl.UserId == userId && !cl.IsDeleted);
             
             // if the user didn't like  this comment before 
             if(commentLike == null)
@@ -135,16 +138,21 @@ public class CommentLikeService :  ICommentLikeService
             
             await _unitOfWork.CommentLikes.RemoveAsync(commentLike);
             
-            comment.Result.IsDeleted = true;
-            comment.Result.CommentLikes.Remove(commentLike);
-            comment.Result.LikeCount--;
+            
+            if (comment.CommentLikes != null)
+                comment.CommentLikes.Remove(commentLike);
+            
+            if (comment.LikeCount > 0)
+                    comment.LikeCount--;
+            
+           _unitOfWork.Comments.Update(comment);
             
             await _unitOfWork.SaveAsync();
             
         }
         catch (Exception e)
         {
-            Console.WriteLine(e);
+            _logger.LogError(e, "Failed to delete like by user {UserId} on comment {CommentId}", userId, commentId);
             throw;
         }
     }

--- a/AskFm/AskFm.BLL/Services/CommentService.cs
+++ b/AskFm/AskFm.BLL/Services/CommentService.cs
@@ -1,0 +1,21 @@
+using AskFm.DAL.Interfaces;
+using AskFm.DAL.Models;
+
+namespace AskFm.BLL.Services;
+
+public class CommentService : ICommentService
+{
+    private IUnitOfWork _unitOfWork;
+    public CommentService(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+    
+    public Comment GetComment(int commentId)
+    {
+        var comment = _unitOfWork.Comments.GetById(commentId);
+        return comment;
+    }
+
+    
+}

--- a/AskFm/AskFm.BLL/Services/ICommentLikeService.cs
+++ b/AskFm/AskFm.BLL/Services/ICommentLikeService.cs
@@ -1,0 +1,10 @@
+using AskFm.BLL.DTO;
+
+namespace AskFm.BLL.Services;
+
+public interface ICommentLikeService
+{
+    Task<IEnumerable<CommentLikeDto>> GetLikesForCommentAsync(int commentId);
+    Task<CommentLikeDto> AddLikeAsync(int commentId, int userId);
+    Task DeleteLikeAsync(int commentId, int userId);
+}

--- a/AskFm/AskFm.BLL/Services/ICommentLikeService.cs
+++ b/AskFm/AskFm.BLL/Services/ICommentLikeService.cs
@@ -6,5 +6,5 @@ public interface ICommentLikeService
 {
     Task<IEnumerable<CommentLikeDto>> GetLikesForCommentAsync(int commentId);
     Task<CommentLikeDto> AddLikeAsync(int commentId, int userId);
-    Task DeleteLikeAsync(int commentId, int userId);
+    Task<bool> DeleteLikeAsync(int commentId, int userId);
 }

--- a/AskFm/AskFm.BLL/Services/ICommentService.cs
+++ b/AskFm/AskFm.BLL/Services/ICommentService.cs
@@ -1,0 +1,8 @@
+using AskFm.DAL.Models;
+
+namespace AskFm.BLL.Services;
+
+public interface ICommentService
+{
+    Comment GetComment(int commentId);
+}

--- a/AskFm/AskFm.BLL/Services/UserIdentityService/IUserService.cs
+++ b/AskFm/AskFm.BLL/Services/UserIdentityService/IUserService.cs
@@ -1,4 +1,5 @@
 using AskFm.BLL.DTO.UserDTOs;
+using AskFm.DAL.Models;
 
 namespace AskFm.BLL.Services.UserIdentityService;
 
@@ -10,7 +11,7 @@ public interface IUserService
     Task<ServiceResult<bool>> UnfollowUserAsync(int followerId, int targetUserId);
     Task UpdateLastSeenAsync(int userId, DateTime lastSeen);
     Task<ServiceResult<ReadUserDTO>> GetUserByIdAsync(int userId);
-    Task<ServiceResult<ReadUserDTO>> GetCurrentUserAsync();
+    Task<ServiceResult<ApplicationUser>> GetCurrentUserAsync();
     Task<ServiceResult<ReadUserDTO>> ResetPassword(string newPassword);
     Task<ServiceResult<ReadUserDTO>> ConfirmEmail();
     

--- a/AskFm/AskFm.BLL/Services/UserIdentityService/UserService.cs
+++ b/AskFm/AskFm.BLL/Services/UserIdentityService/UserService.cs
@@ -52,7 +52,7 @@ public class UserService : IUserService
         throw new NotImplementedException();
     }
 
-    public async Task<ServiceResult<ReadUserDTO>> GetCurrentUserAsync()
+    public async Task<ServiceResult<ApplicationUser>> GetCurrentUserAsync()
     {
         string email = _httpContextAccessor.HttpContext.User.FindFirst(ClaimTypes.Email).Value;
         if (string.IsNullOrEmpty(email))
@@ -61,19 +61,11 @@ public class UserService : IUserService
             {
                 "Can't Access Current user"
             };
-            return await ServiceResult<ReadUserDTO>.Failure(errors);
+            return await ServiceResult<ApplicationUser>.Failure(errors);
         }
         var currentAppUser = await _userManager.FindByEmailAsync(email);
 
-        return await ServiceResult<ReadUserDTO>.Success(new ReadUserDTO()
-        {
-            Name = currentAppUser.Name,
-            Email = currentAppUser.Email,
-            LastSeen = currentAppUser.LastSeen,
-            Bio = currentAppUser.Bio,
-            AvatarPath = currentAppUser.AvatarPath,
-            followerCount = currentAppUser.FollowersCount
-        });
+        return await ServiceResult<ApplicationUser>.Success(currentAppUser);
     }
 
     public Task<ServiceResult<ReadUserDTO>> ResetPassword(string newPassword)

--- a/AskFm/AskFm.DAL/Interfaces/IUnitOfWork.cs
+++ b/AskFm/AskFm.DAL/Interfaces/IUnitOfWork.cs
@@ -1,5 +1,5 @@
 using AskFm.DAL.Models;
-using Thread = System.Threading.Thread;
+using Thread = AskFm.DAL.Models.Thread;
 
 namespace AskFm.DAL.Interfaces;
 

--- a/AskFm/AskFm.DAL/UnitOfWork.cs
+++ b/AskFm/AskFm.DAL/UnitOfWork.cs
@@ -1,7 +1,7 @@
 using AskFm.DAL.Interfaces;
 using AskFm.DAL.Models;
 using AskFm.DAL.Repositories;
-using Thread = System.Threading.Thread;
+using Thread = AskFm.DAL.Models.Thread;
 
 namespace AskFm.DAL;
 

--- a/AskFm/Tests/CommentLikeServiceTest.cs
+++ b/AskFm/Tests/CommentLikeServiceTest.cs
@@ -90,7 +90,7 @@ public class CommentLikeServiceTest
     
     
     [Fact]
-    public void DeleteLike_WhenDeleteByAuthor_CommentIsDeleted()
+    public async void DeleteLike_WhenDeleteByAuthor_CommentIsDeleted()
     {
         var commentId = 1;
         var userId = 5;
@@ -128,7 +128,7 @@ public class CommentLikeServiceTest
         
         
         // Act
-        _commentLikeService.DeleteLikeAsync(commentId, userId);
+        await _commentLikeService.DeleteLikeAsync(commentId, userId);
         
         
         

--- a/AskFm/Tests/CommentLikeServiceTest.cs
+++ b/AskFm/Tests/CommentLikeServiceTest.cs
@@ -77,14 +77,14 @@ public class CommentLikeServiceTest
         // Arrange
         var commentId = 1000;
         var userId = 5;
-        _mockCommentRepository.Setup(repo => repo.GetById(commentId))
-            .Returns((Comment)null);
+        _mockCommentRepository.Setup(repo => repo.GetByIdAsync(commentId))
+            .ReturnsAsync((Comment)null);
         
         // Assert
         await Assert.ThrowsAsync<ArgumentException>(() => _commentLikeService.AddLikeAsync(commentId, userId));
         
-        _mockCommentLikeRepository.Verify(repo => repo.Add(It.IsAny<CommentLike>()), Times.Never);
-        _mockUnitOfWork.Verify(uow => uow.Save(), Times.Never);
+        _mockCommentLikeRepository.Verify(repo => repo.AddAsync(It.IsAny<CommentLike>()), Times.Never);
+        _mockUnitOfWork.Verify(uow => uow.SaveAsync(), Times.Never);
         
     }
     

--- a/AskFm/Tests/CommentLikeServiceTest.cs
+++ b/AskFm/Tests/CommentLikeServiceTest.cs
@@ -72,7 +72,7 @@ public class CommentLikeServiceTest
     }
 
     [Fact]
-    public async void AddLike_WhenCommentNotFoundOrDeleted_ThrowException()
+    public async Task AddLike_WhenCommentNotFoundOrDeleted_ThrowException()
     {
         // Arrange
         var commentId = 1000;
@@ -90,7 +90,7 @@ public class CommentLikeServiceTest
     
     
     [Fact]
-    public async void DeleteLike_WhenDeleteByAuthor_CommentIsDeleted()
+    public async Task DeleteLike_WhenDeleteByAuthor_CommentIsDeleted()
     {
         var commentId = 1;
         var userId = 5;
@@ -144,7 +144,7 @@ public class CommentLikeServiceTest
 
 
     [Fact]
-    public async void GetLikesForComment_WhenCommentLikesIsNotEmpty_ReturnsCommentLikesList()
+    public async Task GetLikesForComment_WhenCommentLikesIsNotEmpty_ReturnsCommentLikesList()
     {
         var commentId = 1;
         var userId = 4;
@@ -199,7 +199,7 @@ public class CommentLikeServiceTest
     
     
     [Fact]
-    public async void GetLikesForComment_WhenCommentLikesIsEmpty_ReturnsEmptyList()
+    public async Task GetLikesForComment_WhenCommentLikesIsEmpty_ReturnsEmptyList()
     {
         // Arrange
         var commentId = 1;

--- a/AskFm/Tests/CommentLikeServiceTest.cs
+++ b/AskFm/Tests/CommentLikeServiceTest.cs
@@ -1,0 +1,244 @@
+using AskFm.BLL.Services;
+using AskFm.DAL.Interfaces;
+using AskFm.DAL.Models;
+using AutoMapper;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Linq.Expressions;
+using AskFm.BLL.DTO;
+
+
+namespace Tests;
+
+public class CommentLikeServiceTest
+{
+    private readonly Mock<IUnitOfWork> _mockUnitOfWork;
+    private readonly Mock<ILogger<CommentLikeService>> _loggerMock;
+    private readonly Mock<IRepository<Comment>> _mockCommentRepository;
+    private readonly Mock<IRepository<ApplicationUser>> _mockUserRepository;
+    private readonly Mock<IRepository<CommentLike>> _mockCommentLikeRepository;
+    private readonly CommentLikeService _commentLikeService;
+    
+    public CommentLikeServiceTest()
+    {
+        _mockUnitOfWork = new Mock<IUnitOfWork>();
+        _mockCommentRepository = new Mock<IRepository<Comment>>();
+        _mockCommentLikeRepository = new Mock<IRepository<CommentLike>>();
+        _mockUserRepository = new Mock<IRepository<ApplicationUser>>();
+        _loggerMock = new Mock<ILogger<CommentLikeService>>();
+        _mockUnitOfWork.Setup(uow => uow.Comments).Returns(_mockCommentRepository.Object);
+        _mockUnitOfWork.Setup(uow => uow.CommentLikes).Returns(_mockCommentLikeRepository.Object);
+        _mockUnitOfWork.Setup(uow => uow.Users).Returns(_mockUserRepository.Object);
+        
+        
+        _commentLikeService = new CommentLikeService(_mockUnitOfWork.Object,  _loggerMock.Object);
+    }
+    
+    [Fact]
+    public async Task AddLike_WhenCommentIsNotDeleted_AddingNewLikeOnTheComment()
+    {
+        // Arrange 
+        var commentId = 1;
+        var userId = 5;
+        
+        var comment = new Comment 
+        { 
+            Id = commentId, 
+            IsDeleted = false,
+            Content = "Test comment"
+        };
+        
+        var user = new ApplicationUser()
+        {
+            Id = userId,
+            Comments = new List<Comment> { comment }
+        };
+        
+        
+        _mockCommentRepository.Setup(repo => repo.GetByIdAsync(commentId))
+            .ReturnsAsync(comment);
+
+        _mockUserRepository.Setup(repo => repo.GetByIdAsync(userId))
+            .ReturnsAsync(user);
+        
+        // Act
+        await _commentLikeService.AddLikeAsync(commentId, userId);
+        
+        // Assert
+        _mockCommentLikeRepository.Verify(repo => repo.AddAsync(It.Is<CommentLike>(cl => 
+            cl.CommentId == commentId && cl.UserId == userId)), Times.Once);
+        
+        _mockUnitOfWork.Verify(uow => uow.SaveAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async void AddLike_WhenCommentNotFoundOrDeleted_ThrowException()
+    {
+        // Arrange
+        var commentId = 1000;
+        var userId = 5;
+        _mockCommentRepository.Setup(repo => repo.GetById(commentId))
+            .Returns((Comment)null);
+        
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => _commentLikeService.AddLikeAsync(commentId, userId));
+        
+        _mockCommentLikeRepository.Verify(repo => repo.Add(It.IsAny<CommentLike>()), Times.Never);
+        _mockUnitOfWork.Verify(uow => uow.Save(), Times.Never);
+        
+    }
+    
+    
+    [Fact]
+    public void DeleteLike_WhenDeleteByAuthor_CommentIsDeleted()
+    {
+        var commentId = 1;
+        var userId = 5;
+
+        var commentLike = new CommentLike { CommentId = commentId, UserId = userId };
+
+        _mockCommentLikeRepository.Setup(repo =>
+                repo.FindAsync(
+                    It.Is<Expression<Func<CommentLike, bool>>>(expr =>
+                        ExpressionMatches(expr, userId, commentId)),
+                    It.IsAny<string[]>()
+                ))
+            .Returns(Task.FromResult(commentLike));
+
+        var likeCount = 1;
+
+        ICollection<CommentLike> commentLikes = new List<CommentLike>();
+        commentLikes.Add(commentLike);
+        
+        var comment = new Comment()
+        {
+            Id = commentId,
+            Content = "Test comment",
+            IsDeleted = false,
+            CommentLikes = commentLikes,
+            LikeCount = likeCount
+        };
+        
+        _mockCommentRepository.Setup(repo => repo.GetByIdAsync(commentId))
+            .Returns(Task.FromResult(comment));
+
+        
+        _mockCommentLikeRepository.Setup(repo => repo.RemoveAsync(commentLike))
+            .Callback(() => commentLike.IsDeleted = true);
+        
+        
+        // Act
+        _commentLikeService.DeleteLikeAsync(commentId, userId);
+        
+        
+        
+        // Assert 
+        
+        Assert.Empty(comment.CommentLikes);
+        Assert.True(commentLike.IsDeleted);
+        Assert.Equal(comment.LikeCount, likeCount - 1);
+        _mockCommentLikeRepository.Verify(repo => repo.RemoveAsync(commentLike), Times.Once);
+        _mockUnitOfWork.Verify(uow => uow.SaveAsync(), Times.Once);
+
+    }
+
+
+    [Fact]
+    public async void GetLikesForComment_WhenCommentLikesIsNotEmpty_ReturnsCommentLikesList()
+    {
+        var commentId = 1;
+        var userId = 4;
+        
+
+        ICollection<CommentLike> commentLikes = new List<CommentLike>()
+        {
+            { new CommentLike { CommentId = commentId, UserId = 4 }},
+            { new CommentLike { CommentId = commentId, UserId = 5 } },
+            { new CommentLike { CommentId = commentId, UserId = 6 } },
+            { new CommentLike { CommentId = commentId, UserId = 8 } },
+            { new CommentLike { CommentId = commentId, UserId = 9 } },
+        };
+
+        
+        
+        var comment = new Comment()
+        {
+            Id = commentId,
+            Content = "Test comment",
+            IsDeleted = false,
+            CommentLikes = commentLikes
+        };
+        
+        var expectedDtos = new List<CommentLikeDto>
+        {
+            new CommentLikeDto {CommentId = commentId, UserId = 4 },
+            new CommentLikeDto {CommentId = commentId, UserId = 5 },
+            new CommentLikeDto {CommentId = commentId, UserId = 6 },
+            new CommentLikeDto {CommentId = commentId, UserId = 8 },
+            new CommentLikeDto {CommentId = commentId, UserId = 9 }
+        };
+        
+        _mockCommentRepository.Setup(repo => repo.GetByIdAsync(commentId))
+            .ReturnsAsync(comment);
+        
+        _mockCommentLikeRepository.Setup(repo => 
+                repo.FindAllAsync(It.IsAny<Expression<Func<CommentLike, bool>>>(), It.IsAny<string[]>()))
+            .ReturnsAsync(commentLikes);
+        
+        // Act
+        var result = await _commentLikeService.GetLikesForCommentAsync(commentId);
+        
+        
+        // Assert 
+        Assert.NotNull(result);
+        Assert.Equal(5, result.Count());
+
+        Assert.Equivalent(expectedDtos, result);
+        
+    }
+    
+    
+    [Fact]
+    public async void GetLikesForComment_WhenCommentLikesIsEmpty_ReturnsEmptyList()
+    {
+        // Arrange
+        var commentId = 1;
+        var userId = 4;
+        
+        ICollection<CommentLike> commentLikes = new List<CommentLike>();
+        
+        var comment = new Comment()
+        {
+            Id = commentId,
+            Content = "Test comment",
+            IsDeleted = false,
+            CommentLikes = commentLikes
+        };
+        
+        _mockCommentRepository.Setup(repo => repo.GetByIdAsync(commentId))
+            .ReturnsAsync(comment);
+        
+        _mockCommentLikeRepository.Setup(repo => 
+                repo.FindAllAsync(It.IsAny<Expression<Func<CommentLike, bool>>>(), It.IsAny<string[]>()))
+            .ReturnsAsync(commentLikes);
+        
+        // Act
+        var result = await _commentLikeService.GetLikesForCommentAsync(commentId);
+        
+        
+        // Assert
+        Assert.Empty(result);
+        
+    }
+    
+    
+    // helper
+    private bool ExpressionMatches(Expression<Func<CommentLike, bool>> expr, int userId, int commentId)
+    {
+        var testItem = new CommentLike { UserId = userId, CommentId = commentId };
+        var compiled = expr.Compile();
+        return compiled(testItem);
+    }
+
+    
+}

--- a/AskFm/Tests/Tests.csproj
+++ b/AskFm/Tests/Tests.csproj
@@ -10,12 +10,17 @@
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.2"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
     </ItemGroup>
 
     <ItemGroup>
         <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\AskFm.API\AskFm.API.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Key implementations 

- renamed "current-user" endpoint to be "profile"
- changed the return type for `GetCurrentUser` on `UserService` from `ServiceResult<ReadUserDto>` to `ServiceResult<ApplicationUser>`
- changed the implementation of the 'profile' endpoint to map the returned `ServiceResult<ApplicationUser>` to map it to `ReadUserDto`