### PR TITLE
Current User new  implementation 

### DIFF
--- a/AskFm/AskFm.API/Controllers/UserController.cs
+++ b/AskFm/AskFm.API/Controllers/UserController.cs
@@ -37,16 +37,25 @@ public class UserController : ControllerBase
     }
 
     [HttpGet]
-    [Route("current-user")]
+    [Route("profile")]
     public async Task<IActionResult> GetCurrentUserAsync()
     {
         var result = await _userService.GetCurrentUserAsync();
-
+        
         if (!result.success)
         {
             return BadRequest(result.Errors);
         }
-        return Ok(result.Data);
+        ReadUserDTO readUserDTO = new ReadUserDTO()
+        {
+            Name = result.Data.Name,
+            Email = result.Data.Email,
+            AvatarPath = result.Data.AvatarPath,
+            Bio = result.Data.Bio,
+            followerCount = result.Data.FollowersCount,
+            LastSeen = result.Data.LastSeen,
+        };
+        return Ok(readUserDTO);
     }
     /*
   GET Users only for now

--- a/AskFm/AskFm.BLL/Services/UserIdentityService/IUserService.cs
+++ b/AskFm/AskFm.BLL/Services/UserIdentityService/IUserService.cs
@@ -1,4 +1,5 @@
 using AskFm.BLL.DTO.UserDTOs;
+using AskFm.DAL.Models;
 
 namespace AskFm.BLL.Services.UserIdentityService;
 
@@ -10,7 +11,7 @@ public interface IUserService
     Task<ServiceResult<bool>> UnfollowUserAsync(int followerId, int targetUserId);
     Task UpdateLastSeenAsync(int userId, DateTime lastSeen);
     Task<ServiceResult<ReadUserDTO>> GetUserByIdAsync(int userId);
-    Task<ServiceResult<ReadUserDTO>> GetCurrentUserAsync();
+    Task<ServiceResult<ApplicationUser>> GetCurrentUserAsync();
     Task<ServiceResult<ReadUserDTO>> ResetPassword(string newPassword);
     Task<ServiceResult<ReadUserDTO>> ConfirmEmail();
     

--- a/AskFm/AskFm.BLL/Services/UserIdentityService/UserService.cs
+++ b/AskFm/AskFm.BLL/Services/UserIdentityService/UserService.cs
@@ -52,7 +52,7 @@ public class UserService : IUserService
         throw new NotImplementedException();
     }
 
-    public async Task<ServiceResult<ReadUserDTO>> GetCurrentUserAsync()
+    public async Task<ServiceResult<ApplicationUser>> GetCurrentUserAsync()
     {
         string email = _httpContextAccessor.HttpContext.User.FindFirst(ClaimTypes.Email).Value;
         if (string.IsNullOrEmpty(email))
@@ -61,19 +61,11 @@ public class UserService : IUserService
             {
                 "Can't Access Current user"
             };
-            return await ServiceResult<ReadUserDTO>.Failure(errors);
+            return await ServiceResult<ApplicationUser>.Failure(errors);
         }
         var currentAppUser = await _userManager.FindByEmailAsync(email);
 
-        return await ServiceResult<ReadUserDTO>.Success(new ReadUserDTO()
-        {
-            Name = currentAppUser.Name,
-            Email = currentAppUser.Email,
-            LastSeen = currentAppUser.LastSeen,
-            Bio = currentAppUser.Bio,
-            AvatarPath = currentAppUser.AvatarPath,
-            followerCount = currentAppUser.FollowersCount
-        });
+        return await ServiceResult<ApplicationUser>.Success(currentAppUser);
     }
 
     public Task<ServiceResult<ReadUserDTO>> ResetPassword(string newPassword)


### PR DESCRIPTION
# Key implementations 

- renamed "current-user" endpoint to be "profile"
- changed the return type for `GetCurrentUser` on `UserService` from `ServiceResult<ReadUserDto>` to `ServiceResult<ApplicationUser>`
- changed the implementation of the 'profile' endpoint to map the returned `ServiceResult<ApplicationUser>` to map it to `ReadUserDto`
